### PR TITLE
update dependencies, fix #4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: colorplaner
 Type: Package
 Title: ggplot2 Extension to Visualize Two Variables per Color Aesthetic Through
     Color Space Projection
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Date: 2016-07-21
 Author: William Murphy
 Maintainer: William Murphy <william.murphy.rd@gmail.com>
@@ -14,14 +14,14 @@ Description: Add additional dimensionality to visualizations by using the color
 License: GPL-3
 LazyData: TRUE
 Imports:
-    grid (>= 3.2.2),
-    scales (>= 0.3.0),
-    gtable (>= 0.1.2),
-    digest (>= 0.6.8),
+    grid,
+    scales,
+    gtable,
+    digest,
     methods
 Depends:
-    R (>= 3.2.2),
-    ggplot2 (>= 2.1.0)
+    R (>= 3.1),
+    ggplot2 (>= 2.0.0)
 Suggests:
     testthat,
     maps,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.0.0.9006
+* Removed unnecessary package version requirements. Still requires at least ggplot2 v2.0.0 for the extension system. 
+
 # Version 0.0.0.9005
 * Color aesthetic maps correctly when both scale_color_colorplane and scale_fill_colorplane used in same plot (#1) 
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,9 @@ To install:
 devtools::install_github("wmurphyrd/colorplaner")
 ```
 
+#### Version 0.0.0.9006
+* Removed unnecessary package version requirements. Still requires at least ggplot2 v2.0.0 for the extension system. 
+
 #### Version 0.0.0.9005
 * Color aesthetic maps correctly when both scale_color_colorplane and scale_fill_colorplane used in same plot (#1) 
 


### PR DESCRIPTION
Remove unnecessary minimum versions for dependencies. Tested for compatibility with ggplot2 v2.0.0 (relying on minimums set by ggplot2 for shared dependencies)