### PR TITLE
Improved handling of layers without colorplane mapping. Fix #19

### DIFF
--- a/R/ScaleColorPlane.R
+++ b/R/ScaleColorPlane.R
@@ -19,12 +19,24 @@ ScaleColorPlane <- ggplot2::ggproto("ScaleColorPlane", ggplot2::ScaleContinuous,
   na.color = NULL,
   projection_function = NULL,
   projection_function_args = list(),
+  # tracks if error has been displayed to avoid repeated messages
+  has_error = FALSE,
   map_df = function(self, df, i = NULL) {
     if (is.null(df) || nrow(df) == 0 || ncol(df) == 0) return()
+    if(length(self$aesthetics) != 2 || self$is_empty()) {
+      if(!self$has_error) {
+        message("No valid colorplane mapping found. ",
+                ifelse("colour" %in% self$aesthetics,
+                       "scale_color_colorplane requires both color and color2",
+                       "scale_fill_colorplane requires both fill and fill2"),
+              " aesthetics to be mapped.")
+        self$has_error <- TRUE
+      }
+      return()
+    }
     aes_check <- intersect(self$aesthetics, names(df))
-    if (length(aes_check) == 0) return()
     if (length(aes_check) != 2) {
-      message("Number of aesthetics not equal to 2:", aesthetics)
+      # silently skip layers that don't have colorplane mapping
       return()
     }
 
@@ -67,10 +79,7 @@ ScaleColorPlane <- ggplot2::ggproto("ScaleColorPlane", ggplot2::ScaleContinuous,
     aesthetics <- aesthetics[c(grep("[[:digit:]]", aesthetics, invert = TRUE),
                                grep("[[:digit:]]", aesthetics))]
     names(aesthetics) <- aesthetics
-
-    if (length(aesthetics) == 0) return()
     if (length(aesthetics) != 2) {
-      message("Number of aesthetics not equal to 2:", aesthetics)
       return()
     }
     self$aesthetics <- aesthetics

--- a/tests/testthat/test_scale_training.R
+++ b/tests/testthat/test_scale_training.R
@@ -1,0 +1,27 @@
+aqd <- airquality[complete.cases(airquality), ]
+aqm <- lm(Ozone ~ Temp, aqd)
+aqd <- cbind(aqd, predict(aqm, newdata = aqd,
+                          interval = "prediction"))
+
+test_that("Plots with static color layers succeed", {
+  expect_silent(
+    print(ggplot(aqd, aes(x = Temp, y = Ozone, color = Solar.R, color2 = Wind)) +
+    geom_ribbon(aes(ymin = lwr, ymax = upr), alpha = .35, color = NA) +
+    geom_point() +
+    geom_rug() +
+    scale_color_colorplane())
+  )
+})
+
+test_that("Plots with no valid mapping give informative message", {
+  expect_message({
+    print(ggplot(aqd, aes(x = Temp, y = Ozone, color= Solar.R)) +
+      geom_point() +
+      scale_color_colorplane())
+  }, "scale_color_colorplane requires both color and color2")
+  expect_message({
+    print(ggplot(aqd, aes(x = Temp, y = Ozone, color= Solar.R)) +
+      geom_point() +
+      scale_fill_colorplane())
+  }, "scale_fill_colorplane requires both fill and fill2")
+})


### PR DESCRIPTION
Silently passes over layers to which colorplane is not mapped. Gives informative message if no layers map  correctly to colorplane. 